### PR TITLE
Append / to RESOURCEPATH

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@ EXTRA_DIST = doc/ \
 						 player/ \
 						 resources/
 
-AM_CPPFLAGS = -DRESOURCEPATH=\"$(prefix)/share/komposter\"
+AM_CPPFLAGS = -DRESOURCEPATH=\"$(prefix)/share/komposter/\"
 
 komposter_SOURCES = about.c \
 										audio.c \


### PR DESCRIPTION
RESOURCEPATH requires an additional `/` otherwise it's looking for `$(prefix)/share/komposterm42.TTF`.